### PR TITLE
Fix typo

### DIFF
--- a/powerbi-docs/developer/visuals/visuals-how-to-debug.md
+++ b/powerbi-docs/developer/visuals/visuals-how-to-debug.md
@@ -73,7 +73,7 @@ public update(options: VisualUpdateOptions) {
 
 Sie können den Browser auch so einrichten, dass bei abgefangenen Ausnahmen die Ausführung unterbrochen wird. Damit wird die Codeausführung angehalten, sobald ein Fehler auftritt, und Sie können das Debuggen ab diesem Punkt fortsetzen.
 
-### <a name="edge"></a>Microsot Edge
+### <a name="edge"></a>Microsoft Edge
 
 1. Öffnen Sie die Entwicklertools (F12).
 2. Wechseln Sie zur Registerkarte **Debugger**.


### PR DESCRIPTION
Microsot→Microsoft

Hilfreiche Informationen zum Einreichen eines Vorschlags:
1. Wechseln Sie zu [Quick Start Localization Style Guides (Style Guides für die Lokalisierung – Schnellstart)](https://docs.microsoft.com/globalization/localization/styleguides), und lesen Sie die **10 wichtigsten Regeln** aus dem Style Guide von Microsoft.
2. Wechseln Sie zum [Microsoft-Sprachenportal](https://www.microsoft.com/language), um eine **standardisierte Begriffsübersetzung** für Microsoft-Produkte zu überprüfen.
